### PR TITLE
Add feature admin can change user status

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -2,4 +2,18 @@ class Admin::UsersController < Admin::BaseController
   def index
     @users = User.filter_by_status(params[:status])
   end
+
+  def update
+    @user = User.find(params[:id])
+    if @user.update(user_params)
+      flash[:info] = "#{@user.name}'s status has been changed to #{@user.status}"
+      redirect_to admin_users_path
+    end
+  end
+
+  private
+
+    def user_params
+      params.require(:user).permit(:status)
+    end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,6 +7,7 @@ class User < ActiveRecord::Base
   validates :fullname, presence: true
   validates :email, presence: true, uniqueness: true
   validates :password_digest, presence: true
+  validates :status, presence: true, inclusion: { in: %w(active suspended) }
 
   enum role: %w(default admin super_admin)
 

--- a/app/views/admin/users/_user.html.erb
+++ b/app/views/admin/users/_user.html.erb
@@ -1,13 +1,12 @@
-<tr id="<%= user.fullname %>">
+<tr id="user-<%= user.id %>">
   <td class="col-md-2"><%= link_to "#{user.id}","#" %></td>
   <td class="text-nowrap col-md-6"><%= link_to "#{user.name}","#"%></td>
-  <td class="col-md-2">
-    <select>
-      <option selected="selected" value="active">active</option>
-      <option value="suspended">suspended</option>
-    </select>
-  </td>
-  <td class="col-md-2">
-    <button class="btn btn-checkout btn-s">update status</button>
-  </td>
+  <%= form_for(user, url: admin_user_path(user.id), method: :patch) do |f| %>
+    <td class="col-md-2">
+    <%= f.select(:status, ["active", "suspended"]) %>
+    </td>
+    <td class="col-md-2">
+      <%= f.submit "update status", class: "btn btn-checkout btn-s" %>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/admin/users/index.html.erb
+++ b/app/views/admin/users/index.html.erb
@@ -1,5 +1,5 @@
 <h3 class="<%= params[:status] %> admin-order-index-header">active users</h3><br>
-<p><%= link_to "all users", admin_users_path(status: "all") %>&bull; <%= link_to "active users", admin_users_path(status: "active") %> &bull; <%= link_to "suspended users", admin_users_path(status: "suspended") %></p>
+<p><%= link_to "all users", admin_users_path(status: "all") %> &bull; <%= link_to "active users", admin_users_path(status: "active") %> &bull; <%= link_to "suspended users", admin_users_path(status: "suspended") %></p>
 <br>
 <div class="row">
   <div class="col-sm-3">

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -31,7 +31,7 @@ Rails.application.routes.draw do
     resources :products, only: [:new, :create, :index, :update]
     resources :orders, only: [:index, :show, :update]
     resources :comments, only: [:create]
-    resources :users, only: [:index]
+    resources :users, only: [:index, :update]
     resources :events, only: [:index, :new]
     resources :venues, only: [:index, :new]
     resources :categories, only: [:index, :new]

--- a/spec/features/admin/users/admin_can_change_user_status_spec.rb
+++ b/spec/features/admin/users/admin_can_change_user_status_spec.rb
@@ -9,6 +9,10 @@ RSpec.feature "AdminCanChangeUserStatuses", type: :feature do
                          email:      "admin@example.com",
                          password:   "password",
                          role: 1)
+    @user2 = User.create(fullname: "Jane Adams",
+                         email: "janeadams@example.com",
+                         password: "password",
+                         status: "suspended")
     ApplicationController.any_instance.stub(:current_user) { @admin }
   end
 
@@ -31,6 +35,29 @@ RSpec.feature "AdminCanChangeUserStatuses", type: :feature do
     within(".users") do
       expect(page).to have_content @user.name
       expect(page).to have_content @user.id
+    end
+  end
+
+  scenario "see user on active users page" do
+    visit "/admin/dashboard"
+    click_on "users"
+    click_on "suspended users"
+
+    within("#user-#{@user2.id}") do
+      select "active", from: "user_status"
+      click_on "update status"
+    end
+
+    expect(page).to have_content "Jane Adams's status has been changed to active"
+    within(".users") do
+      expect(page).to have_content @user2.name
+      expect(page).to have_content @user2.id
+    end
+
+    click_on "suspended users"
+    within(".users") do
+      expect(page).to_not have_content @user2.name
+      expect(page).to_not have_content @user2.id
     end
   end
 end

--- a/spec/features/admin/users/admin_can_change_user_status_spec.rb
+++ b/spec/features/admin/users/admin_can_change_user_status_spec.rb
@@ -1,0 +1,36 @@
+require "rails_helper"
+
+RSpec.feature "AdminCanChangeUserStatuses", type: :feature do
+  before(:each) do
+    @user = User.create(fullname: "Abe Lincoln",
+                        email: "honestabe@example.com",
+                        password: "password")
+    @admin = User.create(fullname: "John Adams",
+                         email:      "admin@example.com",
+                         password:   "password",
+                         role: 1)
+    ApplicationController.any_instance.stub(:current_user) { @admin }
+  end
+
+  scenario "see user on suspended users page" do
+    visit "/admin/dashboard"
+    click_on "users"
+
+    within("#user-#{@user.id}") do
+      select "suspended", from: "user_status"
+      click_on "update status"
+    end
+
+    expect(page).to have_content "Abe Lincoln's status has been changed to suspended"
+    within(".users") do
+      expect(page).to_not have_content @user.name
+      expect(page).to_not have_content @user.id
+    end
+
+    click_on "suspended users"
+    within(".users") do
+      expect(page).to have_content @user.name
+      expect(page).to have_content @user.id
+    end
+  end
+end

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -5,7 +5,8 @@ RSpec.describe User, type: :model do
   it { should validate_presence_of :fullname}
   it { should validate_presence_of :email}
   it { should validate_presence_of :password_digest}
-
+  it { should validate_presence_of :status }
+  it { should validate_inclusion_of(:status).in_array(%w(active suspended)) }
 
   it { should have_many :order_products }
   it { should have_many :orders }


### PR DESCRIPTION
User story:
as a logged in admin
I visit '/admin/dashboard'
I click on 'users'
I select suspended
I click on update user
I should not see the user on the page
I click on suspended users
I should see the newly suspended user on the page
- Added feature test
- Added admin/users#update
- Changed partial admin/user to have an update form

closes #31
