### PR TITLE
Admin can create and update categories

### DIFF
--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -1,4 +1,25 @@
 class Admin::CategoriesController < Admin::BaseController
   def index
+    @categories = Category.all
   end
+
+  def new
+    @category = Category.new
+  end
+
+  def create
+    @category = Category.new(category_params)
+    if @category.save
+      flash[:info] = "Created category: #{@category.name}"
+      redirect_to admin_categories_path
+    else
+      render "admin/categories/new"
+    end
+  end
+
+  private
+
+    def category_params
+      params.require(:category).permit(:name)
+    end
 end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -13,7 +13,20 @@ class Admin::CategoriesController < Admin::BaseController
       flash[:info] = "Created category: #{@category.name}"
       redirect_to admin_categories_path
     else
+      flash[:error] = "Sorry, could not create that new category."
       render "admin/categories/new"
+    end
+  end
+
+  def update
+    @category = Category.find(params[:id])
+    if @category.update(category_params)
+      flash[:info] = "Updated category: #{@category.name}"
+      redirect_to admin_categories_path
+    else
+      flash[:error] = "sorry, unable to update category"
+      @categories = Category.all
+      render "admin/categories/index"
     end
   end
 

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -13,7 +13,7 @@ class Admin::CategoriesController < Admin::BaseController
       flash[:info] = "Created category: #{@category.name}"
       redirect_to admin_categories_path
     else
-      flash[:error] = "Sorry, could not create that new category."
+      flash.now[:error] = "Sorry, could not create that new category."
       render "admin/categories/new"
     end
   end
@@ -24,7 +24,7 @@ class Admin::CategoriesController < Admin::BaseController
       flash[:info] = "Updated category: #{@category.name}"
       redirect_to admin_categories_path
     else
-      flash[:error] = "sorry, unable to update category"
+      flash.now[:error] = "sorry, unable to update category"
       @categories = Category.all
       render "admin/categories/index"
     end

--- a/app/controllers/admin/categories_controller.rb
+++ b/app/controllers/admin/categories_controller.rb
@@ -14,7 +14,7 @@ class Admin::CategoriesController < Admin::BaseController
       redirect_to admin_categories_path
     else
       flash.now[:error] = "Sorry, could not create that new category."
-      render "admin/categories/new"
+      render :new
     end
   end
 
@@ -26,7 +26,7 @@ class Admin::CategoriesController < Admin::BaseController
     else
       flash.now[:error] = "sorry, unable to update category"
       @categories = Category.all
-      render "admin/categories/index"
+      render :index
     end
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,5 +3,4 @@ class Category < ActiveRecord::Base
 
   validates :name, presence: true
   validates :name, uniqueness: true
-  
 end

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -3,8 +3,5 @@ class Category < ActiveRecord::Base
 
   validates :name, presence: true
   validates :name, uniqueness: true
-
-  def active_products
-    products.active_products
-  end
+  
 end

--- a/app/views/admin/categories/_category.html.erb
+++ b/app/views/admin/categories/_category.html.erb
@@ -1,6 +1,10 @@
-<tr>
-  <td class="col-md-4 col-md-offset-3 text-left"><input type="text" value="<%= "#{category.name}" %>" name="category[name]" class="text-left"></td>
+<tr id="category-<%= category.id %>">
+  <%= form_for [:admin, category] do |f| %>
+    <td class="col-md-4 col-md-offset-3 text-left">
+      <%= f.text_field :name, value: "#{category.name}" %>
+    </td>
     <td class="col-md-2">
-      <button class="btn btn-checkout btn-s text-center">update category</button>
-  </td>
+      <%= f.submit "update category", class: "btn btn-checkout btn-s text-center" %>
+    </td>
+  <% end %>
 </tr>

--- a/app/views/admin/categories/_category.html.erb
+++ b/app/views/admin/categories/_category.html.erb
@@ -1,0 +1,6 @@
+<tr>
+  <td class="col-md-4 col-md-offset-3 text-left"><input type="text" value="<%= "#{category.name}" %>" name="category[name]" class="text-left"></td>
+    <td class="col-md-2">
+      <button class="btn btn-checkout btn-s text-center">update category</button>
+  </td>
+</tr>

--- a/app/views/admin/categories/index.html.erb
+++ b/app/views/admin/categories/index.html.erb
@@ -11,15 +11,8 @@
         <th class="col-md-2"></th>
       </tr>
     </thead>
-    <tbody>
-    <% 6.times do |n|%>
-      <tr>
-        <td class="col-md-4 col-md-offset-3 text-left"><input type="text" value="Category <%="#{n}"%>" name="category[name]" class="text-left"></td>
-        <td class="col-md-2">
-          <button class="btn btn-checkout btn-s text-center">update category</button>
-        </td>
-      </tr>
-    <% end %>
+    <tbody class="categories">
+      <%= render partial: "admin/categories/category", collection: @categories %>
     </tbody>
   </table>
 </div>

--- a/app/views/admin/categories/new.html.erb
+++ b/app/views/admin/categories/new.html.erb
@@ -7,14 +7,16 @@
   <br>
   <div class="row">
     <div id="new-category" class="form-group has success form-div col-xs-6 col-xs-offset-3">
-      <div class="text-left">
-        <label for="category-name">name</label>
-        <input placeholder="name" class="form-control text-input" type="text" name="category[name]" id="category-name">
-        <br>
-      </div>
-      <div class="text-center">
-        <button class="btn btn-little-owl form-center">create category</button>
-      </div>
+      <%= form_for [:admin, @category] do |f| %>
+        <div class="text-left">
+          <%= f.label :name, "name" %>
+          <%= f.text_field :name, class:"form-control text-input"%>
+          <br>
+        </div>
+        <div class="text-center">
+          <%=f.submit "create category", class: "btn btn-little-owl form-center" %>
+        </div>
+      <% end %>
     </div>
   </div>
 </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -36,7 +36,7 @@ Rails.application.routes.draw do
     resources :users, only: [:index, :update]
     resources :events, only: [:index, :new]
     resources :venues, only: [:index, :new]
-    resources :categories, only: [:index, :new]
+    resources :categories, only: [:index, :new, :create]
     resources :tags, only: [:index, :new, :show]
   end
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -30,13 +30,13 @@ Rails.application.routes.draw do
 
   namespace :admin do
     get "/dashboard", to: "events#index"
-    resources :products, only: [:new, :create, :index, :update]
-    resources :orders, only: [:index, :show, :update]
+    #resources :products, only: [:new, :create, :index, :update]
+    #resources :orders, only: [:index, :show, :update]
     resources :comments, only: [:create]
     resources :users, only: [:index, :update]
     resources :events, only: [:index, :new]
     resources :venues, only: [:index, :new]
-    resources :categories, only: [:index, :new, :create]
+    resources :categories, only: [:index, :new, :create, :update]
     resources :tags, only: [:index, :new, :show]
   end
 

--- a/spec/features/admin/admin_can_create_a_new_category_spec.rb
+++ b/spec/features/admin/admin_can_create_a_new_category_spec.rb
@@ -19,4 +19,10 @@ RSpec.feature "AdminCanCreateANewCategory", type: :feature do
       expect(page).to have_field "category[name]", with: "Musicals"
     end
   end
+
+  scenario "gets 404 page" do
+    visit 'admin/categories/new'
+
+    expect(page).to have_content "The page you were looking for doesn't exist (404)"
+  end
 end

--- a/spec/features/admin/admin_can_create_a_new_category_spec.rb
+++ b/spec/features/admin/admin_can_create_a_new_category_spec.rb
@@ -5,7 +5,7 @@ RSpec.feature "AdminCanCreateANewCategory", type: :feature do
   scenario "see new category on index page" do
     create_and_stub_admin
 
-    visit '/admin/dashboard'
+    visit "/admin/dashboard"
     click_on "categories"
     click_on "new category"
 
@@ -20,9 +20,25 @@ RSpec.feature "AdminCanCreateANewCategory", type: :feature do
     end
   end
 
-  scenario "gets 404 page" do
-    visit 'admin/categories/new'
+  context "guest user" do
+    scenario "gets 404 page" do
+      visit "admin/categories/new"
 
-    expect(page).to have_content "The page you were looking for doesn't exist (404)"
+      expect(page).to have_content "The page you were looking for doesn't exist (404)"
+    end
+  end
+
+  context "logged in user" do
+    scenario "gets 404 page" do
+      user1
+      visit "/login"
+      fill_in "email", with: "mustachefodays@example.com"
+      fill_in "password", with: "password"
+      click_on "login"
+
+      visit "admin/categories/new"
+
+      expect(page).to have_content "The page you were looking for doesn't exist (404)"
+    end
   end
 end

--- a/spec/features/admin/admin_can_create_a_new_category_spec.rb
+++ b/spec/features/admin/admin_can_create_a_new_category_spec.rb
@@ -1,0 +1,22 @@
+require "rails_helper"
+
+RSpec.feature "AdminCanCreateANewCategory", type: :feature do
+  include SpecHelpers
+  scenario "see new category on index page" do
+    create_and_stub_admin
+
+    visit '/admin/dashboard'
+    click_on "categories"
+    click_on "new category"
+
+    fill_in "name", with: "Musicals"
+    click_on "create category"
+
+    expect(current_path).to eq "/admin/categories"
+
+    expect(page).to have_content "Created category: Musicals"
+    within(".categories") do
+      expect(page).to have_field "category[name]", with: "Musicals"
+    end
+  end
+end

--- a/spec/features/admin/admin_can_create_a_new_category_spec.rb
+++ b/spec/features/admin/admin_can_create_a_new_category_spec.rb
@@ -20,6 +20,38 @@ RSpec.feature "AdminCanCreateANewCategory", type: :feature do
     end
   end
 
+  context "duplicate category name" do
+    scenario "sees creation form and error message" do
+      create_and_stub_admin
+      category1
+
+      visit "/admin/dashboard"
+      click_on "categories"
+      click_on "new category"
+
+      fill_in "name", with: "festivals"
+      click_on "create category"
+
+      expect(page).to have_content "Sorry, could not create that new category."
+    end
+  end
+
+  context "empty category name" do
+    scenario "sees creation form and error message" do
+      create_and_stub_admin
+      category1
+
+      visit "/admin/dashboard"
+      click_on "categories"
+      click_on "new category"
+
+      fill_in "name", with: ""
+      click_on "create category"
+
+      expect(page).to have_content "Sorry, could not create that new category."
+    end
+  end
+
   context "guest user" do
     scenario "gets 404 page" do
       visit "admin/categories/new"

--- a/spec/features/admin/admin_can_update_a_category_name_spec.rb
+++ b/spec/features/admin/admin_can_update_a_category_name_spec.rb
@@ -1,0 +1,89 @@
+require "rails_helper"
+
+RSpec.feature "AdminCanCreateANewCategory", type: :feature do
+  include SpecHelpers
+  scenario "see updated category name on index page" do
+    create_and_stub_admin
+    category1
+
+    visit "/admin/dashboard"
+    click_on "categories"
+
+    fill_in "category[name]", with: "Musicals"
+    click_on "update category"
+
+    expect(current_path).to eq "/admin/categories"
+
+    expect(page).to have_content "Updated category: Musicals"
+    within(".categories") do
+      expect(page).to have_field "category[name]", with: "Musicals"
+      expect(page).not_to have_field "category[name]", with: "festivals"
+    end
+  end
+
+  context "duplicate name" do
+    scenario "sees unable to update category message" do
+      create_and_stub_admin
+      category1
+      category2
+
+      visit "/admin/dashboard"
+      click_on "categories"
+
+      within ("#category-#{category1.id}") do
+        fill_in "category[name]", with: "sports"
+        click_on "update category"
+      end
+
+      expect(page).to have_content "sorry, unable to update category"
+      within(".categories") do
+        expect(page).to have_field "category[name]", with: "festivals"
+        expect(page).to have_field "category[name]", with: "sports"
+      end
+    end
+  end
+
+  context "blank name" do
+    scenario "sees unable to update category message" do
+      create_and_stub_admin
+      category1
+      category2
+
+      visit "/admin/dashboard"
+      click_on "categories"
+
+      within ("#category-#{category1.id}") do
+        fill_in "category[name]", with: ""
+        click_on "update category"
+      end
+
+      expect(page).to have_content "sorry, unable to update category"
+      within(".categories") do
+        expect(page).to have_field "category[name]", with: "festivals"
+        expect(page).to have_field "category[name]", with: "sports"
+      end
+    end
+  end
+
+  context "guest user" do
+    scenario "gets 404 page" do
+      visit "admin/categories"
+
+      expect(page).to have_content "The page you were looking for doesn't exist (404)"
+    end
+  end
+
+  context "logged in user" do
+    scenario "gets 404 page" do
+      user1
+      visit "/login"
+      fill_in "email", with: "mustachefodays@example.com"
+      fill_in "password", with: "password"
+      click_on "login"
+
+      visit "admin/categories"
+
+      expect(page).to have_content "The page you were looking for doesn't exist (404)"
+    end
+  end
+end


### PR DESCRIPTION
User story: 
as a logged in admin
I click on categories
i click on new category
i fill in name
i click on create category
the category appear on the index page
- created the route admin/categories#create
- created an admin category partial
- tests that this functionality is unavailable to a guest user
- cannot create or update a category with duplicate name or empty name

closes #38 and #39
